### PR TITLE
Update devcontainer for on-demand databases

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,15 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/git:1": {},
-    "ghcr.io/devcontainers/features/github-cli:1": {}
+    "ghcr.io/devcontainers/features/github-cli:1": {},
+    "ghcr.io/devcontainers/images/postgres": {
+      "version": "16",
+      "plan": "onDemand"
+    },
+    "ghcr.io/devcontainers/images/redis": {
+      "version": "7",
+      "plan": "onDemand"
+    }
   },
   "forwardPorts": [
     5432,

--- a/.github/codespaces/prebuild.yml
+++ b/.github/codespaces/prebuild.yml
@@ -13,8 +13,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Create Codespace
-        uses: github/devcontainers-action@v1
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push dev container image
+        uses: devcontainers/ci@v0.3
         with:
           imageName: ghcr.io/${{ github.repository }}/codespace:latest
           cacheFrom: ghcr.io/${{ github.repository }}/codespace:latest
+          push: always
+


### PR DESCRIPTION
## Summary
- use devcontainer features for Postgres and Redis with `plan: onDemand`
- forward port 4186 for LangSmith
- configure Codespaces prebuild workflow to build and push image

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'sample_agent')*
- `pre-commit run --files .devcontainer/devcontainer.json .github/codespaces/prebuild.yml` *(fails: `.pre-commit-config.yaml` is not a file)*

------
https://chatgpt.com/codex/tasks/task_e_684eebb6cf1c8327bd0476b4ee58d260