### PR TITLE
feat: add typed state models

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 requires-python = ">=3.8"
 dependencies = [
     "requests>=2.31",
+    "pydantic>=2.6",
 ]
 authors = [
     { name = "Umbra Versa", email = "admin@umbraversa.com" },
@@ -29,5 +30,5 @@ dev = "python -m sample_agent.cli"
 test = "pytest tests"
 
 [tool.setuptools]
-packages = ["sample_agent"]
+packages = ["sample_agent", "uv_agentic"]
 package-dir = {"" = "src"}

--- a/src/uv_agentic/__init__.py
+++ b/src/uv_agentic/__init__.py
@@ -1,0 +1,9 @@
+"""UV Agentic core package."""
+
+from .state_schemas import PlanningState, ExecutionState, SummaryState
+
+__all__ = [
+    "PlanningState",
+    "ExecutionState",
+    "SummaryState",
+]

--- a/src/uv_agentic/state_schemas.py
+++ b/src/uv_agentic/state_schemas.py
@@ -1,0 +1,40 @@
+"""Pydantic state models for LangGraph stages."""
+
+from __future__ import annotations
+
+from typing import List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class PlanningState(BaseModel):
+    """State for the planning stage."""
+
+    goal: str = Field(..., description="Overall goal the agent is pursuing")
+    plan: Optional[List[str]] = Field(
+        default=None, description="List of planned actions to achieve the goal"
+    )
+
+
+class ExecutionState(BaseModel):
+    """State while executing a plan."""
+
+    goal: str = Field(..., description="Overall goal the agent is pursuing")
+    plan: List[str] = Field(..., description="List of actions to execute")
+    last_step: Optional[str] = Field(
+        default=None, description="The action most recently executed"
+    )
+    steps_completed: List[str] = Field(
+        default_factory=list, description="Actions completed so far"
+    )
+
+
+class SummaryState(BaseModel):
+    """State for summarization after execution."""
+
+    goal: str = Field(..., description="Overall goal the agent was pursuing")
+    plan: List[str] = Field(..., description="Executed plan")
+    summary: Optional[str] = Field(
+        default=None, description="Final summary of execution"
+    )
+

--- a/src/uv_agentic/state_schemas.py
+++ b/src/uv_agentic/state_schemas.py
@@ -4,20 +4,28 @@ from __future__ import annotations
 
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, ConfigDict
 
 
 class PlanningState(BaseModel):
     """State for the planning stage."""
+
+    model_config = ConfigDict(extra="forbid")
 
     goal: str = Field(..., description="Overall goal the agent is pursuing")
     plan: Optional[List[str]] = Field(
         default=None, description="List of planned actions to achieve the goal"
     )
 
+    def __str__(self) -> str:
+        diff = self.model_dump(exclude_none=True, exclude_defaults=True)
+        return f"PlanningState({diff})"
+
 
 class ExecutionState(BaseModel):
     """State while executing a plan."""
+
+    model_config = ConfigDict(extra="forbid")
 
     goal: str = Field(..., description="Overall goal the agent is pursuing")
     plan: List[str] = Field(..., description="List of actions to execute")
@@ -28,13 +36,23 @@ class ExecutionState(BaseModel):
         default_factory=list, description="Actions completed so far"
     )
 
+    def __str__(self) -> str:
+        diff = self.model_dump(exclude_none=True, exclude_defaults=True)
+        return f"ExecutionState({diff})"
+
 
 class SummaryState(BaseModel):
     """State for summarization after execution."""
+
+    model_config = ConfigDict(extra="forbid")
 
     goal: str = Field(..., description="Overall goal the agent was pursuing")
     plan: List[str] = Field(..., description="Executed plan")
     summary: Optional[str] = Field(
         default=None, description="Final summary of execution"
     )
+
+    def __str__(self) -> str:
+        diff = self.model_dump(exclude_none=True, exclude_defaults=True)
+        return f"SummaryState({diff})"
 

--- a/tests/test_state_schemas.py
+++ b/tests/test_state_schemas.py
@@ -1,0 +1,10 @@
+from uv_agentic import PlanningState, ExecutionState, SummaryState
+
+
+def test_state_instantiation():
+    planning = PlanningState(goal="test goal", plan=["step1", "step2"])
+    assert planning.goal == "test goal"
+    exec_state = ExecutionState(goal="goal", plan=["step1"])  # minimal
+    assert exec_state.steps_completed == []
+    summary = SummaryState(goal="goal", plan=["step1"], summary="done")
+    assert summary.summary == "done"

--- a/tests/test_state_schemas.py
+++ b/tests/test_state_schemas.py
@@ -8,3 +8,17 @@ def test_state_instantiation():
     assert exec_state.steps_completed == []
     summary = SummaryState(goal="goal", plan=["step1"], summary="done")
     assert summary.summary == "done"
+
+
+def test_extra_keys_forbidden():
+    try:
+        PlanningState(goal="x", plan=[], junk=1)
+    except Exception as exc:  # Pydantic ValidationError
+        assert "Extra inputs are not permitted" in str(exc)
+    else:
+        raise AssertionError("extra keys not forbidden")
+
+
+def test_str_shows_diff():
+    state = ExecutionState(goal="g", plan=["a"], last_step=None)
+    assert str(state) == "ExecutionState({'goal': 'g', 'plan': ['a']})"


### PR DESCRIPTION
## Summary
- define pydantic state models for LangGraph stages
- expose new models in `uv_agentic`
- include new package in build config
- test state model instantiation

## Testing
- `python -m pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eeb704fa08327a5467505e08a7263