### PR TITLE
Expose package in devcontainer

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Set PYTHONPATH so editors inside the container resolve package imports
+export PYTHONPATH=/workspace/UV-agentic-project-repo-template/src:$PYTHONPATH

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+"""Initialize the src package for editable installs."""


### PR DESCRIPTION
## Summary
- mark `src` as a package with an `__init__`
- set `PYTHONPATH` in a new `.devcontainer/postCreate.sh`

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eeb62fb448327bd9645a51fbd9b7e